### PR TITLE
Fixed missing option in json diff

### DIFF
--- a/src/cmd/api/middleware/expect.go
+++ b/src/cmd/api/middleware/expect.go
@@ -44,7 +44,8 @@ func ExpectationValidator(logger *zap.Logger) gin.HandlerFunc {
 
 		c.Next()
 
-		diff, description := jsondiff.Compare(requestCopy.Bytes(), responseCopy.Bytes(), nil)
+		opts := jsondiff.DefaultConsoleOptions()
+		diff, description := jsondiff.Compare(requestCopy.Bytes(), responseCopy.Bytes(), &opts)
 		if diff != jsondiff.FullMatch {
 			logger.Error("response body does not match the expected response body",
 				zap.String("endpoint", c.FullPath()),


### PR DESCRIPTION
The output is not perfect as it's optimized for console and only after pasting it to echo gives beautiful result with with colors. Do you have any idea how to achieve this using our logs?